### PR TITLE
fix: ensure version consistency between local builds and GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,13 @@ jobs:
 
       - name: Build binary
         run: |
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev-${{ github.sha }}")
+          # Use same version logic as build.sh
+          VERSION=$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "")
+          if [ -z "$VERSION" ]; then
+            VERSION="dev-${{ github.sha }}"
+          else
+            VERSION=$(echo "$VERSION" | sed 's/^v//')
+          fi
           COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
           BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')
           

--- a/build.sh
+++ b/build.sh
@@ -34,10 +34,11 @@ fi
 mkdir -p "$BUILD_DIR"
 
 # Get version info
-# Try to get semantic version from git tags first
-VERSION=$(git describe --tags --exact-match 2>/dev/null || echo "")
+# Try to get semantic version from git tags first (including annotated tags)
+VERSION=$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "")
+
 if [ -z "$VERSION" ]; then
-    # If no exact tag, check if we're on a known branch
+    # If no tags, check if we're on a known branch
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
     if [ "$BRANCH" = "main" ]; then
         VERSION="1.0.0-dev"
@@ -47,6 +48,9 @@ if [ -z "$VERSION" ]; then
     else
         VERSION="dev-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
     fi
+else
+    # Clean up git describe output (remove 'v' prefix if present)
+    VERSION=$(echo "$VERSION" | sed 's/^v//')
 fi
 
 COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")


### PR DESCRIPTION
## Summary
- Update build.sh to prioritize Git tags over date-based versions
- Sync CI workflow version logic with build.sh  
- Remove 'v' prefix from Git tag versions for consistency

## Problem
Previously, local builds would show different versions than GitHub releases:
- Local: `0.20250703.X-dev`
- GitHub: `1.2.0`

## Solution
Now when building from a tagged commit:
- Local: `1.2.0` (matches GitHub release)
- GitHub: `1.2.0`

## Test Plan
- [x] Test build script with and without Git tags
- [x] Verify version logic matches between build.sh and CI
- [x] Confirm 'v' prefix is properly stripped

🤖 Generated with [Claude Code](https://claude.ai/code)