### PR TITLE
feat: replace date-based versions with standard semantic versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,13 @@ jobs:
 
       - name: Build binary
         run: |
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev-${{ github.sha }}")
+          # Use same version logic as build.sh
+          VERSION=$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "")
+          if [ -z "$VERSION" ]; then
+            VERSION="dev-${{ github.sha }}"
+          else
+            VERSION=$(echo "$VERSION" | sed 's/^v//')
+          fi
           COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
           BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,10 @@ jobs:
           # Use same version logic as build.sh
           VERSION=$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "")
           if [ -z "$VERSION" ]; then
-            VERSION="dev-${{ github.sha }}"
+            COMMIT_COUNT=$(git rev-list --count HEAD 2>/dev/null || echo "0")
+            MINOR=$((COMMIT_COUNT / 10))
+            PATCH=$((COMMIT_COUNT % 10))
+            VERSION="0.${MINOR}.${PATCH}-ci"
           else
             VERSION=$(echo "$VERSION" | sed 's/^v//')
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,11 @@ jobs:
             echo "branch=main" >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT
           else
-            # Development release - use pre-release versioning
+            # Development release - use semantic pre-release versioning  
             COMMIT_COUNT=$(git rev-list --count HEAD)
-            VERSION="0.$(date +%Y%m%d).${COMMIT_COUNT}-beta"
+            MINOR=$((COMMIT_COUNT / 10))
+            PATCH=$((COMMIT_COUNT % 10))
+            VERSION="0.${MINOR}.${PATCH}-beta"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "branch=develop" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT

--- a/build.sh
+++ b/build.sh
@@ -38,15 +38,20 @@ mkdir -p "$BUILD_DIR"
 VERSION=$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "")
 
 if [ -z "$VERSION" ]; then
-    # If no tags, check if we're on a known branch
+    # If no tags, use semantic versioning based on branch
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+    COMMIT_COUNT=$(git rev-list --count HEAD 2>/dev/null || echo "0")
+    COMMIT_SHORT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    
     if [ "$BRANCH" = "main" ]; then
         VERSION="1.0.0-dev"
     elif [ "$BRANCH" = "develop" ]; then
-        COMMIT_COUNT=$(git rev-list --count HEAD 2>/dev/null || echo "0")
-        VERSION="0.$(date +%Y%m%d).${COMMIT_COUNT}-dev"
+        # Use 0.x.y format for development
+        MINOR=$((COMMIT_COUNT / 10))  # Increment minor every 10 commits
+        PATCH=$((COMMIT_COUNT % 10))  # Patch is remainder
+        VERSION="0.${MINOR}.${PATCH}-dev"
     else
-        VERSION="dev-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+        VERSION="0.0.0-dev-${COMMIT_SHORT}"
     fi
 else
     # Clean up git describe output (remove 'v' prefix if present)

--- a/build.sh
+++ b/build.sh
@@ -34,10 +34,11 @@ fi
 mkdir -p "$BUILD_DIR"
 
 # Get version info
-# Try to get semantic version from git tags first
-VERSION=$(git describe --tags --exact-match 2>/dev/null || echo "")
+# Try to get semantic version from git tags first (including annotated tags)
+VERSION=$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "")
+
 if [ -z "$VERSION" ]; then
-    # If no exact tag, check if we're on a known branch
+    # If no tags, check if we're on a known branch
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
     if [ "$BRANCH" = "main" ]; then
         VERSION="1.0.0-dev"
@@ -47,6 +48,9 @@ if [ -z "$VERSION" ]; then
     else
         VERSION="dev-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
     fi
+else
+    # Clean up git describe output (remove 'v' prefix if present)
+    VERSION=$(echo "$VERSION" | sed 's/^v//')
 fi
 
 COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")


### PR DESCRIPTION
## Summary
- Replace date-based versions with proper semantic versioning (semver)
- Use format `0.x.y` for development versions instead of `0.20250703.x`
- Consistent versioning across build.sh, CI, and release workflows

## Changes
- **Before**: `0.20250703.4-beta` (confusing date format)
- **After**: `0.0.7-dev`, `0.1.3-beta` (standard semver)

## Version Logic
- **Minor version**: Increments every 10 commits
- **Patch version**: Remainder of commits (0-9)
- **Pre-release**: `-dev` for develop, `-beta` for releases, `-ci` for CI

## Examples
- Development: `0.0.7-dev`, `0.1.2-dev`
- Pre-releases: `0.0.7-beta`, `0.1.2-beta`  
- Production: `1.0.0`, `1.2.3` (from semantic-release)

🤖 Generated with [Claude Code](https://claude.ai/code)